### PR TITLE
Update Swift Type Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 tools/**/bin
 tools/**/obj
+swift/
+sdk-generator-osx-x64

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 tools/**/bin
 tools/**/obj
-swift/
-sdk-generator-osx-x64

--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/Resources/Mocks.decoding.swift
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/Resources/Mocks.decoding.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension DecodingError {
+    static func failedToDecodeAnySchema(
+        type: Any.Type,
+        codingPath: [any CodingKey]
+    ) -> Self {
+        fatalError()
+    }
+    
+    public static func verifyAtLeastOneSchemaIsNotNil(
+        _ values: [Any?],
+        type: Any.Type,
+        codingPath: [any CodingKey]
+    ) throws {
+
+    }
+}

--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/Resources/Mocks.swift
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/Resources/Mocks.swift
@@ -7,3 +7,8 @@ public indirect enum IndirectOptional<T: Codable>: Codable {
 @frozen public struct EvaAnyCodable: Codable {
 
 }
+
+@frozen
+public enum JSON: Codable, Equatable, Hashable, Sendable {
+
+}

--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/Resources/Mocks.swift
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/Resources/Mocks.swift
@@ -1,14 +1,18 @@
 ﻿import Foundation
 
-public indirect enum IndirectOptional<T: Codable>: Codable {
+public indirect enum IndirectOptional<T> {
   case none, some(T)
 }
+
+extension IndirectOptional: Codable where T: Codable {}
+extension IndirectOptional: Equatable where T: Equatable {}
+extension IndirectOptional: Hashable where T: Hashable {}
+extension IndirectOptional: Sendable where T: Sendable {}
 
 @frozen public struct EvaAnyCodable: Codable {
 
 }
 
-@frozen
-public enum JSON: Codable, Equatable, Hashable, Sendable {
+@frozen public enum JSON: Codable, Equatable, Hashable, Sendable {
   case null
 }

--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/Resources/Mocks.swift
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/Resources/Mocks.swift
@@ -10,5 +10,5 @@ public indirect enum IndirectOptional<T: Codable>: Codable {
 
 @frozen
 public enum JSON: Codable, Equatable, Hashable, Sendable {
-
+  case null
 }

--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOptions.cs
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOptions.cs
@@ -17,7 +17,7 @@ internal class SwiftOptionsBinder : BaseGenerateOptionsBinder<SwiftOptions>
   internal static readonly OptionWithDefault<string> AnyCodableName = new Option<string>(
     name: "--opt-anycodable-name",
     description: "The name to use for AnyCodable"
-  ).WithDefault("EvaAnyCodable");
+  ).WithDefault("JSON");
 
   internal static readonly OptionWithDefault<bool> OptimisticNullability = new Option<bool>(
     name: "--opt-optimistic-nullability",

--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOutput.cs
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOutput.cs
@@ -164,6 +164,7 @@ internal class SwiftOutput : IOutput<SwiftOptions>
       typeArguments = $"<{typeArguments}>";
     }
 
+    // If the property ID exists, mark the struct as Identifiable.
     var idIndex = type.Properties.ToList().FindIndex(p => p.Key == "ID");
     extends = idIndex == -1 ? extends : $"Identifiable, {extends}";
     extends = string.IsNullOrEmpty(extends) ? "" : $": {extends}";
@@ -201,6 +202,7 @@ internal class SwiftOutput : IOutput<SwiftOptions>
 
       foreach (var (propName, prop) in type.Properties)
       {
+        // If AllowedValues is defined, encode these values in a type safe enum.
         if (prop.AllowedValues.Any())
         {
           output.WriteLine($"public enum {propName}Values: RawRepresentable, Identifiable, Codable, CaseIterable, Equatable, Hashable, Sendable {{");

--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOutput.cs
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOutput.cs
@@ -434,15 +434,7 @@ internal class SwiftOutput : IOutput<SwiftOptions>
             typeNameNotNullable = typeNameNotNullable == "Data" && dataIndex != -1 ? $"Foundation.{typeNameNotNullable}" : typeNameNotNullable;
             if (prop.Value.Type.Nullable)
             {
-              // JSON conforms to ExpressibleByNilLiteral, therefore we do not use optionals. JSON? can be expressed by JSON with a value of .null or nil.
-              if (typeNameNotNullable == "JSON")
-              {
-                output.WriteLine($"self.{prop.Key} = (try? container.decodeIfPresent({typeNameNotNullable}.self, forKey: .{prop.Key})) ?? nil");
-              }
-              else
-              {
-                output.WriteLine($"self.{prop.Key} = try? container.decodeIfPresent({typeNameNotNullable}.self, forKey: .{prop.Key})");
-              }
+              output.WriteLine($"self.{prop.Key} = try? container.decodeIfPresent({typeNameNotNullable}.self, forKey: .{prop.Key})");
             }
             else
             {
@@ -544,7 +536,7 @@ internal class SwiftOutput : IOutput<SwiftOptions>
       if (ctx.Options.OptimisticNullability) element = element.CloneAsNotNull();
       return $"[{GetTypeName(element, ctx)}]{n}";
     }
-    if (typeReference is { Name: ApiSpecConsts.Any }) return $"{ctx.Options.AnyCodableName}";
+    if (typeReference is { Name: ApiSpecConsts.Any }) return $"{ctx.Options.AnyCodableName}{n}";
     if (typeReference is { Name: ApiSpecConsts.WellKnown.IProductSearchItem or ApiSpecConsts.Object }) return $"[String: {ctx.Options.AnyCodableName}]{n}";
     if (typeReference is { Name: ApiSpecConsts.Specials.Map })
     {
@@ -579,8 +571,8 @@ internal class SwiftOutput : IOutput<SwiftOptions>
       return "EVACoreBuckarooGender";
     }
 
-    ctx.Logger.LogWarning("Type cannot be handled by this output: {Type}, outputting as \"object\"", typeReference.Name);
-    return $"{ctx.Options.AnyCodableName}";
+    ctx.Logger.LogWarning("Type cannot be handled by this output: {Type}, outputting as \"any\"", typeReference.Name);
+    return $"{ctx.Options.AnyCodableName}{n}";
   }
 
   private static string GetTypeName(string id, ApiDefinitionModel input)

--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOutput.cs
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOutput.cs
@@ -203,7 +203,7 @@ internal class SwiftOutput : IOutput<SwiftOptions>
       {
         if (prop.AllowedValues.Any())
         {
-          output.WriteLine($"public enum {propName}Values: RawRepresentable, Codable, CaseIterable, Equatable, Hashable, Sendable {{");
+          output.WriteLine($"public enum {propName}Values: RawRepresentable, Identifiable, Codable, CaseIterable, Equatable, Hashable, Sendable {{");
           using(output.Indentation)
           {
             foreach (var allowedValue in prop.AllowedValues)
@@ -226,6 +226,8 @@ internal class SwiftOutput : IOutput<SwiftOptions>
               output.WriteLine("}");
             }
             output.WriteLine("}");
+            output.WriteLine();
+            output.WriteLine("public var id: Self { self }");
             output.WriteLine();
             output.WriteLine("public var rawValue: String {");
             using(output.Indentation)
@@ -444,7 +446,7 @@ internal class SwiftOutput : IOutput<SwiftOptions>
 
   private static void WriteNonFlagsEnum(TypeSpecification type, string typename, IndentedStringBuilder output)
   {
-    output.WriteLine($"public enum {typename}: Int, Codable, Equatable, Hashable, Sendable {{");
+    output.WriteLine($"public enum {typename}: Int, Identifiable, Codable, Equatable, Hashable, Sendable {{");
     using (output.Indentation)
     {
       foreach (var (name, value) in type.EnumValues.OrderBy(v => v.Value.Value))
@@ -452,6 +454,8 @@ internal class SwiftOutput : IOutput<SwiftOptions>
         var safeName = name == "Type" ? "`Type`" : name;
         output.WriteLine($"case {safeName} = {value.Value}");
       }
+      output.WriteLine();
+      output.WriteLine("public var id: Self { self }");
     }
 
     output.WriteLine("}");


### PR DESCRIPTION
This PR includes several improvements to the generated swift types.
The goal was to use all the information of EVA's api spec in the Swift types.
The attached pdf gives a short overview of the improvements.
Please comment if some C# code can be improved, because this is the second time I wrote some C#
[EvaServiceKit.pdf](https://github.com/new-black/eva-apispec/files/12197055/EvaServiceKit.pdf)
