### PR TITLE
fix: use deprecated property for the type for Identifiable

### DIFF
--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOutput.cs
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/swift/SwiftOutput.cs
@@ -363,7 +363,7 @@ internal class SwiftOutput : IOutput<SwiftOptions>
       // Identifiable requirement
       if (type.Properties.TryGetValue("ID", out var idProperty))
       {
-        output.WriteLine($"public var id: {GetPropTypeName(idProperty, "ID", id, ctx)} {{ self.ID }}");
+        output.WriteLine($"public var id: {GetPropTypeName(idProperty, "ID", id, ctx, false, idProperty.Deprecated != null)} {{ self.ID }}");
         output.WriteLine();
       }
 


### PR DESCRIPTION
There was a type that was deprecated and it made the ID type optional. It should also check that for the Identifiable protocol conformance.