### PR TITLE
feat(typescript): add const enum option

### DIFF
--- a/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/typescript/TypescriptOptions.cs
+++ b/tools/EVA.SDK.Generator.V2/Commands/Generate/Outputs/typescript/TypescriptOptions.cs
@@ -9,6 +9,7 @@ internal class TypescriptOptions : GenerateOptions
   internal string? PackagePrefix { get; set; } = TypescriptOptionsBinder.PackagePrefix.Default;
   internal bool Extenders { get; set; } = TypescriptOptionsBinder.Extenders.Default;
   internal bool FlexibleIDs { get; set; } = TypescriptOptionsBinder.FlexibleIDs.Default;
+  internal bool ConstEnums { get; set; } = TypescriptOptionsBinder.ConstEnums.Default;
 }
 
 internal class TypescriptOptionsBinder : BaseGenerateOptionsBinder<TypescriptOptions>
@@ -28,11 +29,17 @@ internal class TypescriptOptionsBinder : BaseGenerateOptionsBinder<TypescriptOpt
     description: "Add flexible types"
   ).WithDefault(false);
 
+  internal static readonly OptionWithDefault<bool> ConstEnums = new Option<bool>(
+    name: "--opt-const-enums",
+    description: "Export const enums"
+  ).WithDefault(true);
+
   protected override IEnumerable<Option> GetOptions()
   {
     yield return PackagePrefix.Option;
     yield return Extenders.Option;
     yield return FlexibleIDs.Option;
+    yield return ConstEnums.Option;
   }
 
   protected override void BuildOptions(TypescriptOptions options, BindingContext ctx)
@@ -43,5 +50,6 @@ internal class TypescriptOptionsBinder : BaseGenerateOptionsBinder<TypescriptOpt
 
     options.Extenders = Extenders.Value(ctx);
     options.FlexibleIDs = FlexibleIDs.Value(ctx);
+    options.ConstEnums = ConstEnums.Value(ctx);
   }
 }


### PR DESCRIPTION
Added an options to make the const enum output optional. Having real enums gives us more runtime (validation) options at the expense of bundle size. For the Admin suite we want to have the option to use real enums.