### PR TITLE
feat(spec): support [Deprecated] on enum values

### DIFF
--- a/tools/EVA.API.Spec/EnumValueSpecification.cs
+++ b/tools/EVA.API.Spec/EnumValueSpecification.cs
@@ -8,4 +8,5 @@ public class EnumValueSpecification
   [JsonPropertyName("value")] public long Value { get; set; }
   [JsonPropertyName("extends")] public ImmutableArray<string> Extends { get; set; } = ImmutableArray<string>.Empty;
   [JsonPropertyName("description")] public string? Description { get; set; }
+  [JsonPropertyName("deprecated")] public TimingInformation? Deprecated { get; set; }
 }


### PR DESCRIPTION
## Summary

Adds a `Deprecated` timing-information field to `EnumValueSpecification`, mirroring the existing `PropertySpecification.Deprecated`. Lets EVA's typings generator surface per-enum-value deprecation in the API spec so downstream consumers (zod, OpenAPI, etc.) can flag them.

## Context

Required by [new-black/eva#17481](https://github.com/new-black/eva/pull/17481), which moves the runtime `[Deprecated]` enum-value check into the source-generated request validation. Once this lands, the EVA-side PR will bump the submodule pointer and populate the field in `TypeSpecificationGenerator` (alongside the existing per-property path).

## Test plan

- [ ] EVA-side PR rebases against this submodule bump and `dotnet build` is clean.
- [ ] Run the API-spec generator against an enum with a `[Deprecated]` member and verify the JSON output emits `"deprecated": { ... }` on the value entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)